### PR TITLE
Bump action runtime from Node 20 to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ outputs:
   file_uid:
     description: The UID of the uploaded file on Nexus Mods
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.4",
-        "@types/node": "^20.19.9",
+        "@types/node": "^24.0.0",
         "@types/node-fetch": "^2.6.12",
         "prettier": "^3.6.2",
         "prettier-eslint": "^16.4.2",
@@ -26,7 +26,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "*"
@@ -3011,13 +3011,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -6393,9 +6393,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "printWidth": 120
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
-    "@types/node": "^20.19.9",
+    "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.6.12",
     "prettier": "^3.6.2",
     "prettier-eslint": "^16.4.2",


### PR DESCRIPTION
Follow-up to #23, as offered in that thread.

GitHub is deprecating the Node 20 actions runtime; actions need to move to Node 24 before the June 2 deadline, after which Node 20 actions will start failing.

## Changes
- `action.yml`: `runs.using: node20` → `node24`
- `package.json`: `engines.node` `>=20` → `>=24`

## Verification
`npm ci`, `npm run check` (tsc), and `npm run build` all pass on Node 24+. Rebuilding produces **no** change to `dist/`, so the committed bundle is untouched — this PR only updates the runtime declaration.

Closes #23